### PR TITLE
Generate unique variable names properly during parsing

### DIFF
--- a/boolean/TinyLang/Boolean/Generator.hs
+++ b/boolean/TinyLang/Boolean/Generator.hs
@@ -29,7 +29,7 @@ import           TinyLang.Var
   in a random expression (but note that repeated Vars should be exactly
   the same, including the Uniqe ID).
 
-  Variable names should be of the form [a-z][a-z0-9]* if they're going
+  Variable names should be of the form [a-z][a-z0-9_]* if they're going
   to be printed and fed to the parser.
 -}
 

--- a/boolean/TinyLang/Boolean/Parser.hs
+++ b/boolean/TinyLang/Boolean/Parser.hs
@@ -1,7 +1,7 @@
 {-| A parser for the boolean language.  The concrete syntax is as follows:
 
   val ::= T | F
-  var ::= [a-z][a-z0-9]*
+  var ::= [a-z][a-z0-9_]*
 
   expr ::= val
            var
@@ -97,7 +97,7 @@ keyword w = (lexeme . try) (string w *> notFollowedBy alphaNumChar)
 identifier :: Parser String
 identifier =  (lexeme . try) (p >>= check)
     where
-      p       = (:) <$> lowerChar <*> many (lowerChar <|> digitChar)
+      p       = (:) <$> lowerChar <*> many (lowerChar <|> digitChar <|> char '_')
       check x = if x `elem` keywords
                 then fail $ "keyword " ++ show x ++ " cannot be an identifier"
                 else return x


### PR DESCRIPTION
I've now updated the parser to deal with variable names properly.  There's still one small problem.  If you include Uniques when you print an expression (Printer.toStringWithIDs) you get names like "x_5" which were previously rejected by the parser because underscores weren't allowed.  I've now changed that so that underscores are allowed. There's still a minor problem in that if you repeatedly print and parse something you'll get names like "x_5_2_2_2_2", which might not be ideal.  We could try to fix this by recognising that "x_5" represents a Unique, but that would be asking for trouble.  (Also, you can just leave out the IDs when printing).