### PR TITLE
[Refac] Using 'Supply' in parsing

### DIFF
--- a/common/TinyLang/ParseUtils.hs
+++ b/common/TinyLang/ParseUtils.hs
@@ -1,10 +1,12 @@
 -- | Some functions/types lifted out of the Parser module so that we can use them in ParsableField
 -- TODO: clean up the imports/exports
 
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
 module TinyLang.ParseUtils
     ( Parser
-    , IdentifierState
-    , emptyIdentifierState
+    , Scope
+    , emptyScope
     , ws
     , lexeme
     , symbol
@@ -20,15 +22,16 @@ import           Text.Megaparsec
 import           Text.Megaparsec.Char
 import qualified Text.Megaparsec.Char.Lexer as L
 
--- Stuff for generating new Unique names during parsing.  Based on Name.hs in PlutusCore.
--- IdentifierState maps names onto Vars and remembers a counter for Unique IDs.
-type IdentifierState = (M.Map String Var, Int)
+-- | 'Scope' maps names onto 'Var's.
+type Scope = M.Map String Var
 
-emptyIdentifierState :: IdentifierState
-emptyIdentifierState = (mempty, 0)
+emptyScope :: Scope
+emptyScope = mempty
 
  -- Void -> No custom error messages
-type Parser = ParsecT Void String (TinyLang.Prelude.State IdentifierState)
+type Parser = ParsecT Void String (StateT Scope Supply)
+
+instance (MonadSupply m, Stream s) => MonadSupply (ParsecT e s m)
 
 -- Consume whitespace
 ws :: Parser ()

--- a/test/Field/Textual.hs
+++ b/test/Field/Textual.hs
@@ -44,7 +44,7 @@ forgetIDs (EConstr econstr e)  = case econstr of
 
 prop_Ftest :: (Eq f, TextField f) => SomeUniExpr f -> Either String ()
 prop_Ftest (SomeUniExpr uni expr) = do
-    SomeUniExpr uni' expr' <- parseExpr (exprToString NoIDs expr)
+    SomeUniExpr uni' expr' <- runSupply $ parseExpr (exprToString NoIDs expr)
     let checkResult expr'' =
             when (forgetIDs expr /= forgetIDs expr'') . Left $ concat
                 [ exprToString NoIDs expr


### PR DESCRIPTION
This is some minor refactoring. I also exposed what was `IdentifierState` previously (now is called simply `Scope`), because it's needed downstream. I'll merge right away.