### PR TITLE
Kwxm/add galois field pkg

### DIFF
--- a/library/Data/Field.hs
+++ b/library/Data/Field.hs
@@ -19,7 +19,9 @@ import           Data.Coerce
 import           Data.Maybe
 import           Data.Ratio
 import           Data.Foldable     (asum)
+import qualified Data.Field.Galois as GF
 import           Text.Megaparsec
+import           GHC.TypeLits (KnownNat)
 
 infixl 6 `add`, `sub`
 infixl 7 `mul`, `div`
@@ -223,3 +225,28 @@ class IsNegative f where
     isNegative x = x < 0
 
 instance IsNegative Rational
+
+
+-- | Various instances making Data.Field.Galois.Prime fit our type
+-- classes for fields.  Most of these would generalise to non-prime
+-- fields quite easily, but parsing and printing would require some
+-- work.
+
+instance KnownNat p => Field (GF.Prime p)
+    where add = (+)
+          sub = (-)
+          mul = (*)
+          div = (GF./)
+          zer = 0
+          one = 1
+
+instance KnownNat p => TextField (GF.Prime p)
+    where parseField = GF.toP <$> signedDecimal
+          showField  = show . GF.fromP
+    
+instance KnownNat p =>  AsInteger (GF.Prime p)
+    where asInteger = Just . GF.fromP
+
+instance IsNegative (GF.Prime p) where
+    isNegative _ = False
+

--- a/library/Data/Field.hs
+++ b/library/Data/Field.hs
@@ -20,8 +20,8 @@ import           Data.Maybe
 import           Data.Ratio
 import           Data.Foldable     (asum)
 import qualified Data.Field.Galois as GF
-import           Text.Megaparsec
 import           GHC.TypeLits (KnownNat)
+import           Text.Megaparsec
 
 infixl 6 `add`, `sub`
 infixl 7 `mul`, `div`

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,5 +3,10 @@ resolver: lts-13.15
 packages:
 - .
 
+allow-newer: true
+
 extra-deps:
 - QuickCheck-GenT-0.2.0
+- poly-0.3.2.0
+- semirings-0.5.1
+- galois-field-1.0.0

--- a/test/Field/Textual.hs
+++ b/test/Field/Textual.hs
@@ -8,6 +8,7 @@ module Field.Textual
     ) where
 
 import           TinyLang.Field.Core
+import           TinyLang.Field.BigField
 import           TinyLang.Field.F17
 import           TinyLang.Field.F4913
 import           TinyLang.Field.Parser
@@ -84,12 +85,12 @@ prop_nestedELet bindings body0 = prop_Ftest $ foldr bind body0 bindings where
 test_checkParseGeneric :: TestTree
 test_checkParseGeneric =
     testProperty "checkParseGeneric" $
-        withMaxSuccess 1000 . property $ prop_Ftest @F4913
+        withMaxSuccess 1000 . property $ prop_Ftest @BigField
 
 test_checkParseNestedLets :: TestTree
 test_checkParseNestedLets =
     testProperty "checkParseNestedLets" $
-        withMaxSuccess 100 . property $ prop_nestedELet @F17
+        withMaxSuccess 100 . property $ prop_nestedELet @BigField
 
 test_printerParserRoundtrip :: TestTree
 test_printerParserRoundtrip =
@@ -102,7 +103,7 @@ parsePrint :: String -> String
 parsePrint
     = either id (\(SomeUniExpr _ expr) -> exprToString WithIDs expr)
     . runSupply
-    . parseExpr @Rational
+    . parseExpr @BigField
 
 parsePrintGolden :: String -> String -> TestTree
 parsePrintGolden name expr =

--- a/test/Field/Textual.hs
+++ b/test/Field/Textual.hs
@@ -90,7 +90,7 @@ test_checkParseGeneric =
 test_checkParseNestedLets :: TestTree
 test_checkParseNestedLets =
     testProperty "checkParseNestedLets" $
-        withMaxSuccess 100 . property $ prop_nestedELet @BigField
+        withMaxSuccess 100 . property $ prop_nestedELet @F17
 
 test_printerParserRoundtrip :: TestTree
 test_printerParserRoundtrip =
@@ -103,7 +103,7 @@ parsePrint :: String -> String
 parsePrint
     = either id (\(SomeUniExpr _ expr) -> exprToString WithIDs expr)
     . runSupply
-    . parseExpr @BigField
+    . parseExpr @Rational
 
 parsePrintGolden :: String -> String -> TestTree
 parsePrintGolden name expr =

--- a/test/Field/Textual.hs
+++ b/test/Field/Textual.hs
@@ -85,6 +85,11 @@ prop_nestedELet bindings body0 = prop_Ftest $ foldr bind body0 bindings where
 test_checkParseGeneric :: TestTree
 test_checkParseGeneric =
     testProperty "checkParseGeneric" $
+        withMaxSuccess 1000 . property $ prop_Ftest @F4913
+
+test_checkParseGeneric2 :: TestTree
+test_checkParseGeneric2 =
+    testProperty "checkParseGeneric2" $
         withMaxSuccess 1000 . property $ prop_Ftest @BigField
 
 test_checkParseNestedLets :: TestTree
@@ -96,6 +101,7 @@ test_printerParserRoundtrip :: TestTree
 test_printerParserRoundtrip =
     testGroup "printerParserRoundtrip"
         [ test_checkParseGeneric
+        , test_checkParseGeneric2
         , test_checkParseNestedLets
         ]
 

--- a/tiny-lang.cabal
+++ b/tiny-lang.cabal
@@ -33,6 +33,7 @@ library
         TinyLang.Field.Parser
         TinyLang.Field.Printer
         TinyLang.Field.Rename
+        TinyLang.Field.BigField
         TinyLang.Field.F17
         TinyLang.Field.F4913
     build-depends:
@@ -40,6 +41,8 @@ library
         transformers,
         mtl,
         containers,
+        galois-field,
+        semirings,
         hashable,
         unordered-containers,
         vector,


### PR DESCRIPTION
This allows us to use prime fields from `Data.Field.Galois` in the galois-fields package.  The package implements completely general Galois fields, but using those would require a bit more work.