### PR TITLE
Cache CI builds

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   build:
-    
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -13,18 +13,28 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+
+    - uses: actions/cache@v1
+      name: Cache ~/.stack
+      path: ~/.stack
+      key:  ${{ runner.os }}-stack-root
+
     - name: Install GHC
       run: |
         stack setup
+
     - name: Build Dependencies
       run: |
         stack build --only-dependencies
+
     - name: Build code
       run: |
         stack build
+
     - name: Build tests
       run: |
         stack test --no-run-tests
+
     - name: Run tests
       run: |
         stack test

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -16,5 +16,15 @@ jobs:
     - name: Install GHC
       run: |
         stack setup
+    - name: Build Dependencies
+      run: |
+        stack build --only-dependencies
+    - name: Build code
+      run: |
+        stack build
+    - name: Build tests
+      run: |
+        stack test --no-run-tests
     - name: Run tests
-      run: stack test
+      run: |
+        stack test

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -16,8 +16,9 @@ jobs:
 
     - uses: actions/cache@v1
       name: Cache ~/.stack
-      path: ~/.stack
-      key:  ${{ runner.os }}-stack-root
+      with:
+        path: ~/.stack
+        key:  ${{ runner.os }}-stack-root
 
     - name: Install GHC
       run: |

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -27,14 +27,10 @@ jobs:
       run: |
         stack build --only-dependencies
 
-    - name: Build code
-      run: |
-        stack build
-
-    - name: Build tests
+    - name: Build Code & Tests
       run: |
         stack test --no-run-tests
 
-    - name: Run tests
+    - name: Run Tests
       run: |
         stack test


### PR DESCRIPTION
- enable caching for CI builds, which reduces the build time from [10 min to 1 min](https://github.com/jakzale/tiny-lang/pull/2/checks), and
- add more fine-grained build steps (running tests is separate from building them).