### PR TITLE
[Bug] Return a scope from the type checker rather than the parser

### DIFF
--- a/common/TinyLang/ParseUtils.hs
+++ b/common/TinyLang/ParseUtils.hs
@@ -4,13 +4,7 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module TinyLang.ParseUtils
-    ( Parser
-    , Scope
-    , MonadScope
-    , Scoped (..)
-    , parseBy
-    , parseString
-    , makeVar
+    ( parseString
     , ws
     , lexeme
     , symbol
@@ -23,52 +17,20 @@ module TinyLang.ParseUtils
 import           TinyLang.Prelude           hiding (many, try)
 import           TinyLang.Var
 
-import qualified Data.Map.Strict            as Map
 import           Text.Megaparsec
 import           Text.Megaparsec.Char
 import qualified Text.Megaparsec.Char.Lexer as L
 
--- | 'Scope' maps names onto 'Var's.
-type Scope = Map String Var
-type MonadScope = MonadState Scope
-
-data Scoped a = Scoped
-    { _scopedScope :: Map String Var
-    , _scopedValue :: a
-    } deriving (Functor, Foldable, Traversable)
-
- -- Void -> No custom error messages
-type Parser = ParsecT Void String (StateT Scope Supply)
-
 instance (MonadSupply m, Stream s) => MonadSupply (ParsecT e s m)
 
-parseBy :: MonadSupply m => Parser a -> String -> m (Scoped (Either String a))
-parseBy parser str =
-    liftSupply $
-        runStateT (runParserT (top parser) "" str) mempty <&> \(errOrRes, scope) ->
-            Scoped scope $ first errorBundlePretty errOrRes
-
 parseString
-    :: (ShowErrorComponent e) =>
-       Parsec e String a ->
-       String ->
-       String ->
-       Either String a
+    :: (MonadError String m, ShowErrorComponent e)
+    => Parsec e String a
+    -> String
+    -> String
+    -> m a
 parseString parser fileName str =
-    first errorBundlePretty $ runParser parser fileName str
-
-
--- | Look up a variable name. If we've already seen it, return the corresponding Var;
--- otherwise, increase the Unique counter and use it to construct a new Var.
-makeVar :: (MonadSupply m, MonadScope m) => String -> m Var
-makeVar name = do
-    vars <- get
-    case Map.lookup name vars of
-        Just var -> pure var
-        Nothing  -> do
-            var <- freshVar name
-            put $ Map.insert name var vars
-            pure var
+    liftEither . first errorBundlePretty $ runParser parser fileName str
 
 -- Consume whitespace
 ws :: (MonadParsec e s m, Token s ~ Char) => m ()

--- a/field/TinyLang/Field/Raw/Parser.hs
+++ b/field/TinyLang/Field/Raw/Parser.hs
@@ -172,24 +172,19 @@ module TinyLang.Field.Raw.Parser
     ( pTop
     ) where
 
-import           TinyLang.Prelude               hiding ( option
-                                                       , many
-                                                       , try
-                                                       )
-import           TinyLang.Field.Raw.Core
-import           TinyLang.Field.Existential
-import           TinyLang.Field.UniConst
-import           TinyLang.ParseUtils            hiding ( Parser )
+import           TinyLang.Prelude               hiding (many, option, try)
+
 import           Data.Field
+import           TinyLang.Field.Existential
+import           TinyLang.Field.Raw.Core
+import           TinyLang.Field.UniConst
+import           TinyLang.ParseUtils
 
-
+import qualified Control.Monad.Combinators.Expr as Comb
+import           Data.Set                       (fromList, member)
+import qualified Data.Vector                    as Vector
 import           Text.Megaparsec
 import           Text.Megaparsec.Char
-import qualified Control.Monad.Combinators.Expr as Comb
-import qualified Data.Vector                    as Vector
-import           Data.Set ( fromList
-                          , member
-                          )
 
 type ParserT = ParsecT Void String
 

--- a/field/TinyLang/Field/Typed/Parser.hs
+++ b/field/TinyLang/Field/Typed/Parser.hs
@@ -8,8 +8,7 @@ For the new API please refer to "TinyLang.Field.Raw.Parser".
 
 -}
 module TinyLang.Field.Typed.Parser
-    ( parseBy
-    , parseScopedExpr
+    ( parseScopedExpr
     , parseExpr
     ) where
 
@@ -28,7 +27,7 @@ import qualified Data.Map.Strict                as Map
 
 -- TODO: use a proper @newtype@.
 instance TextField f => IsString (Scoped (Some (Expr f))) where
-    fromString = fmap (either error $ forget Some) . runSupply . parseScopedExpr
+    fromString = either error (fmap $ forget Some) . runSupplyT . parseScopedExpr
 
 instance TextField f => IsString (Some (Expr f)) where
     fromString = _scopedValue <$> fromString
@@ -37,26 +36,19 @@ instance TextField f => IsString (Some (Expr f)) where
 -- If the result is an error, then return the latest 'Scope', otherwise return the 'Scope'
 -- consisting of all free variables of the expression.
 parseScopedExpr
-    :: forall f m. (MonadSupply m, TextField f)
-    => String -> m (Scoped (Either String (SomeUniExpr f)))
+    :: forall f m. (MonadError String m, MonadSupply m, TextField f)
+    => String -> m (Scoped (SomeUniExpr f))
 parseScopedExpr str = do
-    Scoped totalScope errorOrSomeUniExpr <- parseBy (pTop @f) str
-    case errorOrSomeUniExpr of
-        Left err -> return . Scoped totalScope $ Left err
-        Right rawExpr -> do
-            typed <- runExceptT (typeCheck rawExpr)
-            case typed of
-                Left err' -> return . Scoped totalScope $ Left err'
-                Right (SomeOf uni e) -> do
-                    eRen <- renameExpr e
-                    let freeIndices = IntMap.keysSet . unEnv $ exprFreeVarSigns eRen
-                        isFree var = unUnique (_varUniq var) `IntSet.member` freeIndices
-                        freeScope = Map.filter isFree totalScope
-                    return . Scoped freeScope . Right $ SomeOf uni eRen
-                    
+    exprRaw <- parseString (pTop @f) "" str
+    Scoped scopeTotal (SomeOf uni exprTyped) <- typeCheck exprRaw
+    exprTypedRen <- renameExpr exprTyped
+    let indicesFree = IntMap.keysSet . unEnv $ exprFreeVarSigns exprTypedRen
+        isFree var = unUnique (_varUniq var) `IntSet.member` indicesFree
+        scopeFree = Map.filter isFree scopeTotal
+    return . Scoped scopeFree $ SomeOf uni exprTypedRen
 
 -- | Parse a @String@ and return @Either@ an error message or an @Expr@ of some type.
 parseExpr
-    :: forall f m. (MonadSupply m, TextField f)
-    => String -> m (Either String (SomeUniExpr f))
+    :: forall f m. (MonadError String m, MonadSupply m, TextField f)
+    => String -> m (SomeUniExpr f)
 parseExpr = fmap _scopedValue . parseScopedExpr

--- a/test/Field/Textual.hs
+++ b/test/Field/Textual.hs
@@ -50,7 +50,7 @@ forgetIDs (EStatement stat e)  = EStatement (forgetStatementIDs stat) (forgetIDs
 
 prop_Ftest :: (Eq f, TextField f) => SomeUniExpr f -> Either String ()
 prop_Ftest (SomeOf uni expr) = do
-    SomeOf uni' expr' <- runSupply $ parseExpr (exprToString NoIDs expr)
+    SomeOf uni' expr' <- runSupplyT $ parseExpr (exprToString NoIDs expr)
     let checkResult expr'' =
             when (forgetIDs expr /= forgetIDs expr'') . Left $ concat
                 [ exprToString NoIDs expr
@@ -108,7 +108,7 @@ test_printerParserRoundtrip =
 parsePrint :: String -> String
 parsePrint
     = either id (forget $ exprToString WithIDs)
-    . runSupply
+    . runSupplyT
     . parseExpr @Rational
 
 parsePrintGolden :: String -> String -> TestTree

--- a/test/Field/Typed/Textual.hs
+++ b/test/Field/Typed/Textual.hs
@@ -2,15 +2,15 @@ module Field.Typed.Textual
     ( gen_test_typechecking
     ) where
 
-import TinyLang.Var
-import TinyLang.Field.Typed.Core (SomeUniExpr)
-import TinyLang.Field.Typed.TypeChecker
-import Field.TestUtils
+import           Field.TestUtils
+import           TinyLang.Field.Typed.Core        (SomeUniExpr)
+import           TinyLang.Field.Typed.TypeChecker
+import           TinyLang.Var
 
-import Data.String
-import System.FilePath
-import Test.Tasty
-import Test.Tasty.Golden
+import           Data.String
+import           System.FilePath
+import           Test.Tasty
+import           Test.Tasty.Golden
 
 testDir :: FilePath
 testDir = "test" </> "Field" </> "Typed" </> "golden"
@@ -18,8 +18,8 @@ testDir = "test" </> "Field" </> "Typed" </> "golden"
 typeCheckFilePath :: FilePath -> IO (Either String (SomeUniExpr Rational))
 typeCheckFilePath filePath = do
     parsed <- parseFilePath filePath
-    pure $ runSupplyT . typeCheck =<< parsed
-    
+    pure $ runSupplyT . fmap _scopedValue . typeCheck =<< parsed
+
 genTest :: FilePath -> TestTree
 genTest filePath = goldenVsString name golden action
     where name = takeBaseName filePath


### PR DESCRIPTION
The new code was trying to return a `Scope` from the parser, but since the parser doesn't do any scope resolution anymore, the empry scope was always returned. This PR fixes that. 