### PR TITLE
[Field] Converting 'negative' finite field elements to negative integers

### DIFF
--- a/field/TinyLang/Field/Jubjub.hs
+++ b/field/TinyLang/Field/Jubjub.hs
@@ -16,6 +16,9 @@ u :: Integer
 u = -0xd201000000010000
 
 -- This is the long number from the above. Would be nice to statically test they're equal somehow.
+-- | The characteristic of the 'F' field.
+-- >>> toInteger (GF.char (undefined :: F)) == r
+-- True
 r :: Integer
 r = let u2 = u*u in u2*u2 - u2 + 1
 

--- a/library/Data/Field/F17.hs
+++ b/library/Data/Field/F17.hs
@@ -54,9 +54,6 @@ instance Field F17 where
 instance AsInteger F17 where
     asInteger = Just . fromIntegral . unF17
 
-instance IsNegative F17 where
-    isNegative _ = False
-
 -- | Choose a random element uniformly. If you use this in
 -- randomly-generated expressions there's a good chance that you'll
 -- get division by zero (-> undefined).

--- a/stack.yaml
+++ b/stack.yaml
@@ -10,4 +10,4 @@ extra-deps:
 - galois-field-1.0.1
 - bitvec-1.0.2.0
 - vector-algorithms-0.8.0.3
-- quiet-0.2@sha256:60bb3cb8dd4a225557351b6d622147a4e541f1564847e05a81621365a155ad6c,1413
+- quiet-0.2

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -52,7 +52,7 @@ packages:
       size: 416
       sha256: c64a9ec9827f140768c01f1d9df1ed9ec9de2d70682a3822061bbe52cf85006c
   original:
-    hackage: quiet-0.2@sha256:60bb3cb8dd4a225557351b6d622147a4e541f1564847e05a81621365a155ad6c,1413
+    hackage: quiet-0.2
 snapshots:
 - completed:
     size: 499889

--- a/test/Field/TestUtils.hs
+++ b/test/Field/TestUtils.hs
@@ -44,4 +44,3 @@ discoverTests groupName testDir genTest = do
             not (null files) @? "didn't find any " ++ testFileExt ++  " files in " ++ testDir
     let testCases = testFoundAnyFiles : map genTest files
     pure $ testGroup groupName $ testCases
-

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,7 +1,7 @@
 module Main where
 
 import qualified Boolean.Textual     as Boolean (test_printerParserRoundtrip)
-import qualified Field.Axioms        as Field (test_axiomsExamples)
+import qualified Field.Axioms        as Field (test_fields)
 import qualified Field.Raw.Textual   as Raw (gen_test_parsing)
 import qualified Field.Textual       as Field (test_textual)
 import qualified Field.Typed.Textual as Field (gen_test_typechecking)
@@ -10,16 +10,13 @@ import           Test.Tasty
 
 test_all :: IO TestTree
 test_all = do
-    test_rawParsing <- Raw.gen_test_parsing
-    test_typechecking <- Field.gen_test_typechecking
-    pure $
-        testGroup "all"
-        [ Boolean.test_printerParserRoundtrip
-        , Field.test_axiomsExamples
-        , Field.test_textual
-        , test_rawParsing
-        , test_typechecking
+    testGroup "all" <$> sequence
+        [ pure Boolean.test_printerParserRoundtrip
+        , pure Field.test_fields
+        , pure Field.test_textual
+        , Raw.gen_test_parsing
+        , Field.gen_test_typechecking
         ]
 
 main :: IO ()
-main =  defaultMain =<< test_all
+main = defaultMain =<< test_all


### PR DESCRIPTION
Now `asInteger (toInteger (-1) :: AField Jubjub.F)` gives `Just (-1)` instead of `52435875175126190479447740508185965837690552500527637822603658699938581184512`.