### PR TITLE
[Textual] Ditched 'parseField'

### DIFF
--- a/test/Field/Typed/golden/17-binop.golden
+++ b/test/Field/Typed/golden/17-binop.golden
@@ -1,1 +1,1 @@
-SomeOf Field (EConst 1)
+SomeOf Field (EAppBinOp Div (EConst 1) (EConst 1))


### PR DESCRIPTION
Now that we don't have `F4913`, we also don't need to parse fields differently, so we can just drop `parseField`.